### PR TITLE
add two versions (development and production) for browser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,8 @@
                             <target>
                                 <mkdir dir="${destDir}" />
                                 <get src="${upstream.url}/vue.common.js" dest="${destDir}" />
+                                <get src="${upstream.url}/vue.esm.browser.js" dest="${destDir}" />
+                                <get src="${upstream.url}/vue.esm.browser.min.js" dest="${destDir}" />
                                 <get src="${upstream.url}/vue.esm.js" dest="${destDir}" />
                                 <get src="${upstream.url}/vue.js" dest="${destDir}" />
                                 <get src="${upstream.url}/vue.min.js" dest="${destDir}" />


### PR DESCRIPTION
To import Vue.js in a browser via `<script type="module">` we need to used a special version of **Vue.js**:

- **vue.esm.browser.js** for development
- **vue.esm.browser.min.js** for production
